### PR TITLE
Add hosting monitoring support

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python main.py"

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from discord_slash import SlashCommand, SlashContext
 from discord_slash.utils.manage_commands import create_choice, create_option
 import api.auth
 import utils.logger
+import utils.ping
 
 # Slash option types:
 # sub command: 1
@@ -670,6 +671,7 @@ async def fish(ctx:SlashContext):
         await ctx.reply('Looks like the fish were weary of your rod. You caught nothing.')
 
 # Initialization
+utils.ping.host()
 client.run(api.auth.token)
 
 

--- a/utils/ping.py
+++ b/utils/ping.py
@@ -1,0 +1,15 @@
+from flask import Flask
+from threading import Thread
+
+app = Flask('')
+
+@app.route('/')
+def main():
+  return "Isobot lazer is online.", 200
+
+def run():
+    app.run(host="0.0.0.0", port="8080")
+
+def host():
+    server = Thread(target=run)
+    server.start()


### PR DESCRIPTION
### Hosting on Replit
This change allows the hosting to be monitored and calaulated, and also allows replit to work correctly 24/7 non-stop with this client. This adds the handling code, as well as the libraries required to operate it.
Libraries:
- utils.ping

Requires:
- Replit (hosting platform)
- Uptimerobot (monitoring platform)