### PR TITLE
Fix "item not found" error while selling items

### DIFF
--- a/main.py
+++ b/main.py
@@ -571,7 +571,8 @@ async def sell(ctx:SlashContext, name:str, quantity:int=1):
             return
         items[str(ctx.author.id)][str(name)] -= quantity
         ttl = shopitem[name]["sell price"] * quantity
-        currency[str(ctx.author.id)]["wallet"] += int(ttl)
+        currency["wallet"][str(ctx.author.id)] += int(ttl)
+        save()
         localembed = discord.Embed(title='Item sold', description=f'You successfully sold {quantity} {name} for {ttl} coins!', color=discord.Color.random())
         localembed.set_footer(text='Thank you for your business.')
         await ctx.reply(embed=localembed)


### PR DESCRIPTION
### Problem
If a user tried to sell an item, it would say that the item was not available and it's supposed to `return`.

![image](https://user-images.githubusercontent.com/72265661/169151994-e5459093-5203-4762-bec6-215cabbe34ba.png)

But instead, it would remove the item from the user's inventory, and also not give selling price to their inventory.

### Solution
This patch will fix the item lookup error message being returned, as well as the issue where it would not give the user the item's selling price.

![image](https://user-images.githubusercontent.com/72265661/169152537-a0d98528-0a21-4529-8415-230d94992de9.png)
