### PR TITLE
Add implementation for binoculars in `/scout`

### DIFF
--- a/config/shop.json
+++ b/config/shop.json
@@ -155,7 +155,7 @@
         "sell price": 9800,
         "description": "Try scouting with this binoculars, maybe you can find more with it.",
         "collection": null,
-        "avaliable": true,
+        "available": true,
         "giftable": true,
         "sellable": true
     },

--- a/config/shop.json
+++ b/config/shop.json
@@ -151,11 +151,11 @@
     },
     "binoculars": {
         "stylized name": "Binoculars",
-        "buy price": 0,
-        "sell price": 5000,
+        "buy price": 14850,
+        "sell price": 9800,
         "description": "Try scouting with this binoculars, maybe you can find more with it.",
         "collection": null,
-        "avaliable": false,
+        "avaliable": true,
         "giftable": true,
         "sellable": true
     },

--- a/main.py
+++ b/main.py
@@ -103,6 +103,7 @@ async def on_message(ctx):
         items[str(ctx.author.id)]['boar'] = 0
         items[str(ctx.author.id)]['deer'] = 0
         items[str(ctx.author.id)]['dragon'] = 0
+        items[str(ctx.author.id)]['binoculars'] = 0
     save()
 
 #Error handler
@@ -390,6 +391,10 @@ async def scout(ctx:SlashContext):
     chance:int = random.randint(1, 100)
     if (chance <= 90):
         x:int = random.randint(550, 2000)
+        if items[str(ctx.author.id)]['binoculars'] >= 1:
+            x *= 1.425 
+        else:
+            pass
         currency["wallet"][str(ctx.author.id)] += x
         save()
         await ctx.send(embed=discord.Embed(title='What you found', description=f'You searched your area and found {x} coin(s)!'))


### PR DESCRIPTION
### New feature to currency API!
This adds implementation for binoculars in the `` command. It gives an advantage for the user who has it in their inventory by using the formula given below to boost the outcome of the scout command.

Formula: 
```py
x *= 1.425
```

The binocular's never wears off unless and until the user sells all of their binoculars and removes them from their inventory.
