### PR TITLE
Make kick and ban response on `MissingPermissions` funnier

### DIFF
--- a/main.py
+++ b/main.py
@@ -220,7 +220,7 @@ async def balance(ctx:SlashContext, user=None):
 async def kick(ctx:SlashContext, user, reason=None):
     if plugins.moderation == False: pass
     if not ctx.author.guild_permissions.kick_members:
-        raise MissingPermissions
+        await ctx.reply('https://images-ext-1.discordapp.net/external/Iw-w417ErNcl6eO8_uOPU0LGX4JTqtHPfSNFNTD7zJ0/https/media.tenor.com/TY_AmszVhJIAAAPo/oh-yeah-high-kick.mp4')
     else:
         try:
             if reason == None: await user.kick()
@@ -240,7 +240,7 @@ async def kick(ctx:SlashContext, user, reason=None):
 async def ban(ctx:SlashContext, user, reason=None):
     if plugins.moderation == False: pass
     if not ctx.author.guild_permissions.ban_members:
-        raise MissingPermissions
+        await ctx.reply('https://images-ext-2.discordapp.net/external/tD22WVX_FmMn4-fcGXJNHl4pl28nwO_8QsfM8W8PjiU/https/media.tenor.com/_rMM5ICPEukAAAPo/thor-strike.mp4')
     else:
         try:
             if reason == None: await user.ban()

--- a/main.py
+++ b/main.py
@@ -220,7 +220,7 @@ async def balance(ctx:SlashContext, user=None):
 async def kick(ctx:SlashContext, user, reason=None):
     if plugins.moderation == False: pass
     if not ctx.author.guild_permissions.kick_members:
-        await ctx.reply('https://images-ext-1.discordapp.net/external/Iw-w417ErNcl6eO8_uOPU0LGX4JTqtHPfSNFNTD7zJ0/https/media.tenor.com/TY_AmszVhJIAAAPo/oh-yeah-high-kick.mp4')
+        await ctx.reply('https://tenor.com/view/oh-yeah-high-kick-take-down-fight-gif-14272509')
         return
     else:
         try:
@@ -241,7 +241,7 @@ async def kick(ctx:SlashContext, user, reason=None):
 async def ban(ctx:SlashContext, user, reason=None):
     if plugins.moderation == False: pass
     if not ctx.author.guild_permissions.ban_members:
-        await ctx.reply('https://images-ext-2.discordapp.net/external/tD22WVX_FmMn4-fcGXJNHl4pl28nwO_8QsfM8W8PjiU/https/media.tenor.com/_rMM5ICPEukAAAPo/thor-strike.mp4')
+        await ctx.reply('https://tenor.com/view/thor-strike-admin-ban-admin-ban-gif-22545175')
         return
     else:
         try:

--- a/main.py
+++ b/main.py
@@ -221,6 +221,7 @@ async def kick(ctx:SlashContext, user, reason=None):
     if plugins.moderation == False: pass
     if not ctx.author.guild_permissions.kick_members:
         await ctx.reply('https://images-ext-1.discordapp.net/external/Iw-w417ErNcl6eO8_uOPU0LGX4JTqtHPfSNFNTD7zJ0/https/media.tenor.com/TY_AmszVhJIAAAPo/oh-yeah-high-kick.mp4')
+        return
     else:
         try:
             if reason == None: await user.kick()
@@ -241,6 +242,7 @@ async def ban(ctx:SlashContext, user, reason=None):
     if plugins.moderation == False: pass
     if not ctx.author.guild_permissions.ban_members:
         await ctx.reply('https://images-ext-2.discordapp.net/external/tD22WVX_FmMn4-fcGXJNHl4pl28nwO_8QsfM8W8PjiU/https/media.tenor.com/_rMM5ICPEukAAAPo/thor-strike.mp4')
+        return
     else:
         try:
             if reason == None: await user.ban()


### PR DESCRIPTION
### This also fixes the bot not responding when the user has a lack of required permissions to execute a command.
This change doesn't affect the command for ACTUAL moderators.

## How to ban a user
https://tenor.com/view/thor-strike-admin-ban-admin-ban-gif-22545175