### PR TITLE
Make moderation command cooldowns

### DIFF
--- a/main.py
+++ b/main.py
@@ -242,7 +242,7 @@ async def kick(ctx:SlashContext, user, reason=None):
         create_option(name='reason', description='Why you want to ban the user?', option_type=3, required=False)
     ]
 )
-@commands.cooldown(1, (30*60), commands.BucketType.user)
+@commands.cooldown(1, 3, commands.BucketType.user)
 async def ban(ctx:SlashContext, user, reason=None):
     if plugins.moderation == False: pass
     if not ctx.author.guild_permissions.ban_members:

--- a/main.py
+++ b/main.py
@@ -220,6 +220,7 @@ async def balance(ctx:SlashContext, user=None):
         create_option(name='reason', description='Why you want to kick the user?', option_type=3, required=False)
     ]
 )
+@commands.cooldown(1, 3, commands.BucketType.user)
 async def kick(ctx:SlashContext, user, reason=None):
     if plugins.moderation == False: pass
     if not ctx.author.guild_permissions.kick_members:
@@ -241,6 +242,7 @@ async def kick(ctx:SlashContext, user, reason=None):
         create_option(name='reason', description='Why you want to ban the user?', option_type=3, required=False)
     ]
 )
+@commands.cooldown(1, (30*60), commands.BucketType.user)
 async def ban(ctx:SlashContext, user, reason=None):
     if plugins.moderation == False: pass
     if not ctx.author.guild_permissions.ban_members:
@@ -262,6 +264,7 @@ async def ban(ctx:SlashContext, user, reason=None):
         create_option(name='reason', description='Why are you warning the user?', option_type=3, required=True)
     ]
 )
+@commands.cooldown(1, 2, commands.BucketType.user)
 async def warn(ctx:SlashContext, user, reason):
     if plugins.moderation == False: pass
     if not ctx.author.guild_permissions.manage_messages:


### PR DESCRIPTION
### Why moderation command cooldowns? 
**To prevent spam requests and raiding.** This is mainly done to prevent the bot from getting rate-limited (which would lead to more downtime, screw Discord API rate limits). Also, it helps prevent raid behavior and prevents nuking and other stuff.

### Rate limits
- Kick: 3 seconds
- Ban: 3 seconds
- Warn: 2 seconds