### PR TITLE
Add `/prediction` command

### DIFF
--- a/main.py
+++ b/main.py
@@ -897,6 +897,18 @@ async def stroketranslate(ctx:SlashContext, strok: str):
         var = ''.join(arr)
         await ctx.reply(f"{var}")
 
+@slash.slash(
+    name='prediction',
+    description='Randomly predicts a yes/no question.',
+    options=[create_option(name="question", description="What do you want to predict?", option_type=3, required=True)]
+)
+async def prediction(ctx:SlashContext, question:str): ## "question" argument is useless lol argument go BRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR XDDDDD
+    predict = random.randint(1, 2)
+    if predict == 1:
+        await ctx.reply("My prediction is... **Yes!**")
+    elif predict == 2:
+        await ctx.reply("My prediction is... **No!**")
+
 # Initialization
 utils.ping.host()
 client.run(api.auth.token)


### PR DESCRIPTION
# The prediction command
`/prediction` can be used (FOR FUN) to predict a yes or no answer to a question. Please note that the bot simply replies with "yes" or "no" and you shouldn't ALWAYS take it seriously! Have fun!

### Example Images:
![image](https://user-images.githubusercontent.com/72265661/174484241-8732cb2f-7376-4ad5-adde-58915202b13b.png)

![image](https://user-images.githubusercontent.com/72265661/174484348-44e020f7-3697-4f68-8827-aa5a44089ae3.png)
