### PR TITLE
Add custom token support and saving

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -1,3 +1,36 @@
-token = ''
-secret = ''
-public_key = ''
+# Imports
+import json
+import os
+
+# Config
+wdir = os.getcwd()
+
+# Setup
+with open(f'{wdir}/api/runtimeconfig.json', 'r') as f:
+    global config
+    config = json.load(f)
+
+# Commands
+def get_token():
+    """Returns the token in `runtimeconfig.json`, if it exists.\nIf there is no token provided in the config, it will manually ask the user for input and it will autosave it."""
+    if config["token"] == "":
+        print("[!] Looks like you didn't input a token. Would you like to import one?")
+        arg1 = input("[Yes/No/y/n] > ")
+        if arg1.lower() == "y":
+            arg2 = input("Enter your custom token: ")
+            config["token"] = str(arg2)
+            with open(f'{wdir}/api/runtimeconfig.json', 'w+') as f:
+                json.dump(config, f, indent=4)
+            print("[✅] Setup successful!")
+        elif arg1.lower() == "n": return
+    return str(config["token"])
+
+def get_secret():
+    """Returns the bot client secret in `runtimeconfig.json`, if it exists."""
+    if config["secret"] != "": return config["secret"]
+    else: return "Secret has not been set."
+
+def get_public_key():
+    """Returns the bot's public key in `runtimeconfig.json`, if it exists."""
+    if config["public_key"]: return config["public_key"]
+    else: return "Public key has not been set."

--- a/api/runtimeconfig.json
+++ b/api/runtimeconfig.json
@@ -1,0 +1,6 @@
+{
+    "token": "",
+    "secret": "",
+    "public_key": "",
+    "runtime_options": []
+}

--- a/main.py
+++ b/main.py
@@ -1073,7 +1073,7 @@ async def modify_balance(ctx:SlashContext, user:discord.User, modifier:int):
 
 # Initialization
 utils.ping.host()
-client.run(api.auth.token)
+client.run(api.auth.get_token())
 
 
 


### PR DESCRIPTION
### Custom Token Request
This will make the client ask the user if they want to use a custom token (their own token) in console, if the token is not inputed in the `runtimeconfig.json` file. This update doesn't actually change anything with the commands, it just improves the performance and maintenance of the bot.

<h6>NOTE: runtimeconfig.json can be found in `api/runtimeconfig.json`.</h6>