### PR TITLE
Add GPL3.0 license notice upon client startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -88,6 +88,12 @@ class plugins:
 #Events
 @client.event
 async def on_ready():
+    print("""Isobot-lazer  Copyright (C) 2022  PyBotDevs/NKA
+    This program comes with ABSOLUTELY NO WARRANTY; for details run `/w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; run `/c' for details.
+    __________________________________________________\n""")
+    time.sleep(2)
     print(f'Logged in as {client.user.name}.')
     print('Ready to accept commands.')
     await client.change_presence(activity=discord.Activity(type=discord.ActivityType.playing, name=f"Salad"), status=discord.Status.idle)

--- a/main.py
+++ b/main.py
@@ -92,7 +92,8 @@ async def on_ready():
     This program comes with ABSOLUTELY NO WARRANTY; for details run `/w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; run `/c' for details.
-    __________________________________________________\n""")
+    __________________________________________________
+    """)
     time.sleep(2)
     print(f'Logged in as {client.user.name}.')
     print('Ready to accept commands.')


### PR DESCRIPTION
### GPL3.0 License Output
As per the GNU GPL 3.0 License states: If there is terminal interaction with the program, then it should display License info upon use. That's why we added this feature to our client: so that we can reassure the user that we are committed to being open-source.