### PR TITLE
Convert `client_id` number literal to string literal

### DIFF
--- a/scripts/redirect.js
+++ b/scripts/redirect.js
@@ -13,11 +13,11 @@ function github()
     window.location = "https://github.com/" + git_author + "/" + git_repo;
 }
 
-client_id = 953278050135588905;
+client_id = "953278050135588905";
 /**
  * @name invite
  * @description Redirects to the bot's Discord OAuth2 link.
- * @param {number} client_id
+ * @param {string} client_id
  * @param {string} permissions
  * 
  */


### PR DESCRIPTION
[CodeFactor](https://www.codefactor.io/repository/github/pybotdevs/isobot-lazer) found an issue: This number literal will lose precision at runtime.

It's currently on:
[scripts\redirect.js:16](https://www.codefactor.io/repository/github/pybotdevs/isobot-lazer/source/main/scripts/redirect.js#L16)