### PR TITLE
Fix a typo in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-api/rumtimeconfig.json
+api/runtimeconfig.json
 database/currency.json
 database/item.json
 database/warnings.json


### PR DESCRIPTION
When working on a branch to commit to the repository, developers might have to enter their own bot token to debug their work. The exact `runtimeconfig.json` filename was not in .gitignore, which means that if they forget to remove the token, it could get into the pull request and it could get stolen. This is an important dev fix so please pull this change.