### PR TITLE
Add whitespace support to `/stroketranslate`

### DIFF
--- a/config/words.json
+++ b/config/words.json
@@ -25,6 +25,7 @@
     "x" : ["xorg ", "xbox "],
     "y" : ["why ", "you ", "your ", "youre ", "yes "],
     "z" : ["zip ", "zeta "],
+    " " : [" "],
     "~" : ["{tlide} "],
     "`" : ["{acute} "],
     "!" : ["{exclamination_mark} "],

--- a/config/words.json
+++ b/config/words.json
@@ -25,7 +25,7 @@
     "x" : ["xorg ", "xbox "],
     "y" : ["why ", "you ", "your ", "youre ", "yes "],
     "z" : ["zip ", "zeta "],
-    " " : [" "],
+    " " : [""],
     "~" : ["{tlide} "],
     "`" : ["{acute} "],
     "!" : ["{exclamination_mark} "],


### PR DESCRIPTION
### Add whitespace support
This resolves a bug where the `/stroketranslate` command would throw an exception if the user inputted a space in the command's argument. This adds whitespaces to `words.json` so that it will ignore any spaces in the command argument.