### PR TITLE
Fix license disclaimer output

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,12 +63,12 @@ currency_unused = framework.isobot.currency.CurrencyAPI(f'{wdir}/database/curren
 #Events
 @client.event
 async def on_ready():
-    print("""Isobot-lazer  Copyright (C) 2022  PyBotDevs/NKA
-    This program comes with ABSOLUTELY NO WARRANTY; for details run `/w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; run `/c' for details.
-    __________________________________________________
-    """)
+    print("""
+Isobot-lazer  Copyright (C) 2022  PyBotDevs/NKA
+This program comes with ABSOLUTELY NO WARRANTY; for details run `/w'.
+This is free software, and you are welcome to redistribute it
+under certain conditions; run `/c' for details.
+__________________________________________________""")
     time.sleep(2)
     print(f'Logged in as {client.user.name}.')
     print('Ready to accept commands.')


### PR DESCRIPTION
The license disclaimer output contained indent blocks in it which were also printed upon startup. This removes the indent blocks and makes it look neater.