### PR TITLE
Set "max" and "all" as keywords for max amount in `/deposit` and `/withdraw` commands

### DIFF
--- a/main.py
+++ b/main.py
@@ -268,7 +268,7 @@ async def warns_clear(ctx:SlashContext, user):
 )
 async def deposit(ctx:SlashContext, amount):
     if plugins.economy:
-        if amount in ["all", "max"]: amount = currency["wallet"][str(ctx.author.id)]
+        if not amount.isnumeric() and amount in ["all", "max"]: amount = currency["wallet"][str(ctx.author.id)]
         elif currency['bank'] == 0: return await ctx.reply('You don\'t have anything in your bank account.', hidden=True)
         elif amount <= 0: return await ctx.reply('The amount to deposit must be more than `0` coins!', hidden=True)
         elif amount > currency["wallet"][str(ctx.author.id)]: return await ctx.reply('The amount to deposit must not be more than what you have in your wallet!', hidden=True)
@@ -286,7 +286,7 @@ async def deposit(ctx:SlashContext, amount):
 )
 async def withdraw(ctx:SlashContext, amount):
     if plugins.economy:
-        if amount in ["all", "max"]: amount = currency["wallet"][str(ctx.author.id)]
+        if not amount.isnumeric() and amount in ["all", "max"]: amount = currency["wallet"][str(ctx.author.id)]
         elif currency['bank'] == 0: return await ctx.reply('You don\'t have anything in your bank account.', hidden=True)
         elif amount <= 0: return await ctx.reply('The amount to withdraw must be more than `0` coins!', hidden=True)
         elif amount > currency["bank"][str(ctx.author.id)]: return await ctx.reply('The amount to withdraw must not be more than what you have in your bank account!', hidden=True)

--- a/main.py
+++ b/main.py
@@ -268,8 +268,8 @@ async def warns_clear(ctx:SlashContext, user):
 )
 async def deposit(ctx:SlashContext, amount):
     if plugins.economy:
-        if not amount.isnumeric() and amount in ["all", "max"]: amount = currency["wallet"][str(ctx.author.id)]
-        if not amount.isnumeric() and amount not in ["all", "max"]: return await ctx.reply("The amount must be `all`/`max`, or a number.", hidden=True)
+        if not amount.isnumeric() and amount == "max": amount = currency["wallet"][str(ctx.author.id)]
+        if not amount.isnumeric() and amount != "max": return await ctx.reply("The amount must be a number, or `max`.", hidden=True)
         elif currency['bank'] == 0: return await ctx.reply('You don\'t have anything in your bank account.', hidden=True)
         elif amount <= 0: return await ctx.reply('The amount to deposit must be more than `0` coins!', hidden=True)
         elif amount > currency["wallet"][str(ctx.author.id)]: return await ctx.reply('The amount to deposit must not be more than what you have in your wallet!', hidden=True)

--- a/main.py
+++ b/main.py
@@ -270,7 +270,7 @@ async def deposit(ctx:SlashContext, amount):
     if plugins.economy:
         if not amount.isnumeric():
             if amount == "max": amount = currency["wallet"][str(ctx.author.id)]
-            if amount != "max": return await ctx.reply("The amount must be a number, or `max`.", hidden=True)
+            else: return await ctx.reply("The amount must be a number, or `max`.", hidden=True)
         elif currency['bank'] == 0: return await ctx.reply('You don\'t have anything in your bank account.', hidden=True)
         elif int(amount) <= 0: return await ctx.reply('The amount to deposit must be more than `0` coins!', hidden=True)
         elif int(amount) > currency["wallet"][str(ctx.author.id)]: return await ctx.reply('The amount to deposit must not be more than what you have in your wallet!', hidden=True)

--- a/main.py
+++ b/main.py
@@ -287,8 +287,8 @@ async def deposit(ctx:SlashContext, amount):
 )
 async def withdraw(ctx:SlashContext, amount):
     if plugins.economy:
-        if not amount.isnumeric() and amount in ["all", "max"]: amount = currency["wallet"][str(ctx.author.id)]
-        if not amount.isnumeric() and amount not in ["all", "max"]: return await ctx.reply("The amount must be `all`/`max`, or a number.", hidden=True)
+        if not amount.isnumeric() and amount == "max": amount = currency["wallet"][str(ctx.author.id)]
+        if not amount.isnumeric() and amount != "max": return await ctx.reply("The amount must be a number, or `max`.", hidden=True)
         elif currency['bank'] == 0: return await ctx.reply('You don\'t have anything in your bank account.', hidden=True)
         elif amount <= 0: return await ctx.reply('The amount to withdraw must be more than `0` coins!', hidden=True)
         elif amount > currency["bank"][str(ctx.author.id)]: return await ctx.reply('The amount to withdraw must not be more than what you have in your bank account!', hidden=True)

--- a/main.py
+++ b/main.py
@@ -263,12 +263,12 @@ async def warns_clear(ctx:SlashContext, user):
     name='deposit',
     description='Deposits a specified amount of cash into the bank.',
     options=[
-        create_option(name='amount', description='Specify an amount to deposit (leave blank for max)', option_type=4, required=False)
+        create_option(name='amount', description='Specify an amount to deposit (use max for everything)', option_type=4, required=True)
     ]
 )
-async def deposit(ctx:SlashContext, amount=None):
+async def deposit(ctx:SlashContext, amount):
     if plugins.economy:
-        if amount == None: amount = currency["wallet"][str(ctx.author.id)]
+        if amount in ["all", "max"]: amount = currency["wallet"][str(ctx.author.id)]
         elif currency['bank'] == 0: return await ctx.reply('You don\'t have anything in your bank account.', hidden=True)
         elif amount <= 0: return await ctx.reply('The amount to deposit must be more than `0` coins!', hidden=True)
         elif amount > currency["wallet"][str(ctx.author.id)]: return await ctx.reply('The amount to deposit must not be more than what you have in your wallet!', hidden=True)

--- a/main.py
+++ b/main.py
@@ -269,6 +269,7 @@ async def warns_clear(ctx:SlashContext, user):
 async def deposit(ctx:SlashContext, amount):
     if plugins.economy:
         if not amount.isnumeric() and amount in ["all", "max"]: amount = currency["wallet"][str(ctx.author.id)]
+        if not amount.isnumeric() and amount not in ["all", "max"]: return await ctx.reply("The amount must be `all`/`max`, or a number.", hidden=True)
         elif currency['bank'] == 0: return await ctx.reply('You don\'t have anything in your bank account.', hidden=True)
         elif amount <= 0: return await ctx.reply('The amount to deposit must be more than `0` coins!', hidden=True)
         elif amount > currency["wallet"][str(ctx.author.id)]: return await ctx.reply('The amount to deposit must not be more than what you have in your wallet!', hidden=True)
@@ -287,6 +288,7 @@ async def deposit(ctx:SlashContext, amount):
 async def withdraw(ctx:SlashContext, amount):
     if plugins.economy:
         if not amount.isnumeric() and amount in ["all", "max"]: amount = currency["wallet"][str(ctx.author.id)]
+        if not amount.isnumeric() and amount not in ["all", "max"]: return await ctx.reply("The amount must be `all`/`max`, or a number.", hidden=True)
         elif currency['bank'] == 0: return await ctx.reply('You don\'t have anything in your bank account.', hidden=True)
         elif amount <= 0: return await ctx.reply('The amount to withdraw must be more than `0` coins!', hidden=True)
         elif amount > currency["bank"][str(ctx.author.id)]: return await ctx.reply('The amount to withdraw must not be more than what you have in your bank account!', hidden=True)

--- a/main.py
+++ b/main.py
@@ -263,7 +263,7 @@ async def warns_clear(ctx:SlashContext, user):
     name='deposit',
     description='Deposits a specified amount of cash into the bank.',
     options=[
-        create_option(name='amount', description='Specify an amount to deposit (use max for everything)', option_type=4, required=True)
+        create_option(name='amount', description='Specify an amount to deposit (use max for everything)', option_type=3, required=True)
     ]
 )
 async def deposit(ctx:SlashContext, amount):
@@ -281,7 +281,7 @@ async def deposit(ctx:SlashContext, amount):
     name='withdraw',
     description='Withdraws a specified amount of cash from the bank.',
     options=[
-        create_option(name='amount', description='Specify an amount to withdraw (use max for everything)', option_type=4, required=True)
+        create_option(name='amount', description='Specify an amount to withdraw (use max for everything)', option_type=3, required=True)
     ]
 )
 async def withdraw(ctx:SlashContext, amount):

--- a/main.py
+++ b/main.py
@@ -268,7 +268,7 @@ async def warns_clear(ctx:SlashContext, user):
 )
 async def deposit(ctx:SlashContext, amount):
     if plugins.economy:
-        if not amount.isnumeric():
+        if not amount.isdigit():
             if amount == "max": amount = currency["wallet"][str(ctx.author.id)]
             else: return await ctx.reply("The amount must be a number, or `max`.", hidden=True)
         elif currency['bank'] == 0: return await ctx.reply('You don\'t have anything in your bank account.', hidden=True)
@@ -288,9 +288,9 @@ async def deposit(ctx:SlashContext, amount):
 )
 async def withdraw(ctx:SlashContext, amount):
     if plugins.economy:
-        if not amount.isnumeric():
+        if not amount.isdigit():
             if amount == "max": amount = currency["wallet"][str(ctx.author.id)]
-            if amount != "max": return await ctx.reply("The amount must be a number, or `max`.", hidden=True)
+            else: return await ctx.reply("The amount must be a number, or `max`.", hidden=True)
         elif currency['bank'] == 0: return await ctx.reply('You don\'t have anything in your bank account.', hidden=True)
         elif int(amount) <= 0: return await ctx.reply('The amount to withdraw must be more than `0` coins!', hidden=True)
         elif int(amount) > currency["bank"][str(ctx.author.id)]: return await ctx.reply('The amount to withdraw must not be more than what you have in your bank account!', hidden=True)

--- a/main.py
+++ b/main.py
@@ -268,8 +268,9 @@ async def warns_clear(ctx:SlashContext, user):
 )
 async def deposit(ctx:SlashContext, amount):
     if plugins.economy:
-        if not amount.isnumeric() and amount == "max": amount = currency["wallet"][str(ctx.author.id)]
-        if not amount.isnumeric() and amount != "max": return await ctx.reply("The amount must be a number, or `max`.", hidden=True)
+        if not amount.isnumeric():
+            if amount == "max": amount = currency["wallet"][str(ctx.author.id)]
+            if amount != "max": return await ctx.reply("The amount must be a number, or `max`.", hidden=True)
         elif currency['bank'] == 0: return await ctx.reply('You don\'t have anything in your bank account.', hidden=True)
         elif int(amount) <= 0: return await ctx.reply('The amount to deposit must be more than `0` coins!', hidden=True)
         elif int(amount) > currency["wallet"][str(ctx.author.id)]: return await ctx.reply('The amount to deposit must not be more than what you have in your wallet!', hidden=True)
@@ -287,8 +288,9 @@ async def deposit(ctx:SlashContext, amount):
 )
 async def withdraw(ctx:SlashContext, amount):
     if plugins.economy:
-        if not amount.isnumeric() and amount == "max": amount = currency["wallet"][str(ctx.author.id)]
-        if not amount.isnumeric() and amount != "max": return await ctx.reply("The amount must be a number, or `max`.", hidden=True)
+        if not amount.isnumeric():
+            if amount == "max": amount = currency["wallet"][str(ctx.author.id)]
+            if amount != "max": return await ctx.reply("The amount must be a number, or `max`.", hidden=True)
         elif currency['bank'] == 0: return await ctx.reply('You don\'t have anything in your bank account.', hidden=True)
         elif int(amount) <= 0: return await ctx.reply('The amount to withdraw must be more than `0` coins!', hidden=True)
         elif int(amount) > currency["bank"][str(ctx.author.id)]: return await ctx.reply('The amount to withdraw must not be more than what you have in your bank account!', hidden=True)

--- a/main.py
+++ b/main.py
@@ -271,8 +271,8 @@ async def deposit(ctx:SlashContext, amount):
         if not amount.isnumeric() and amount == "max": amount = currency["wallet"][str(ctx.author.id)]
         if not amount.isnumeric() and amount != "max": return await ctx.reply("The amount must be a number, or `max`.", hidden=True)
         elif currency['bank'] == 0: return await ctx.reply('You don\'t have anything in your bank account.', hidden=True)
-        elif amount <= 0: return await ctx.reply('The amount to deposit must be more than `0` coins!', hidden=True)
-        elif amount > currency["wallet"][str(ctx.author.id)]: return await ctx.reply('The amount to deposit must not be more than what you have in your wallet!', hidden=True)
+        elif int(amount) <= 0: return await ctx.reply('The amount to deposit must be more than `0` coins!', hidden=True)
+        elif int(amount) > currency["wallet"][str(ctx.author.id)]: return await ctx.reply('The amount to deposit must not be more than what you have in your wallet!', hidden=True)
         currency["wallet"][str(ctx.author.id)] -= int(amount)
         currency["bank"][str(ctx.author.id)] += int(amount)
         await ctx.send(f'You deposited `{amount}` coin(s) to your bank account.')
@@ -290,8 +290,8 @@ async def withdraw(ctx:SlashContext, amount):
         if not amount.isnumeric() and amount == "max": amount = currency["wallet"][str(ctx.author.id)]
         if not amount.isnumeric() and amount != "max": return await ctx.reply("The amount must be a number, or `max`.", hidden=True)
         elif currency['bank'] == 0: return await ctx.reply('You don\'t have anything in your bank account.', hidden=True)
-        elif amount <= 0: return await ctx.reply('The amount to withdraw must be more than `0` coins!', hidden=True)
-        elif amount > currency["bank"][str(ctx.author.id)]: return await ctx.reply('The amount to withdraw must not be more than what you have in your bank account!', hidden=True)
+        elif int(amount) <= 0: return await ctx.reply('The amount to withdraw must be more than `0` coins!', hidden=True)
+        elif int(amount) > currency["bank"][str(ctx.author.id)]: return await ctx.reply('The amount to withdraw must not be more than what you have in your bank account!', hidden=True)
         currency["wallet"][str(ctx.author.id)] += int(amount)
         currency["bank"][str(ctx.author.id)] -= int(amount)
         await ctx.send(f'You withdrew `{amount}` coin(s) from your bank account.')

--- a/main.py
+++ b/main.py
@@ -281,12 +281,12 @@ async def deposit(ctx:SlashContext, amount):
     name='withdraw',
     description='Withdraws a specified amount of cash from the bank.',
     options=[
-        create_option(name='amount', description='Specify an amount to withdraw (leave blank for max)', option_type=4, required=False)
+        create_option(name='amount', description='Specify an amount to withdraw (use max for everything)', option_type=4, required=True)
     ]
 )
-async def withdraw(ctx:SlashContext, amount=None):
+async def withdraw(ctx:SlashContext, amount):
     if plugins.economy:
-        if amount == None: amount = currency["bank"][str(ctx.author.id)]
+        if amount in ["all", "max"]: amount = currency["wallet"][str(ctx.author.id)]
         elif currency['bank'] == 0: return await ctx.reply('You don\'t have anything in your bank account.', hidden=True)
         elif amount <= 0: return await ctx.reply('The amount to withdraw must be more than `0` coins!', hidden=True)
         elif amount > currency["bank"][str(ctx.author.id)]: return await ctx.reply('The amount to withdraw must not be more than what you have in your bank account!', hidden=True)

--- a/main.py
+++ b/main.py
@@ -269,7 +269,7 @@ async def warns_clear(ctx:SlashContext, user):
 async def deposit(ctx:SlashContext, amount):
     if plugins.economy:
         if not amount.isdigit():
-            if amount == "max": amount = currency["wallet"][str(ctx.author.id)]
+            if str(amount) == "max": amount = currency["wallet"][str(ctx.author.id)]
             else: return await ctx.reply("The amount must be a number, or `max`.", hidden=True)
         elif currency['bank'] == 0: return await ctx.reply('You don\'t have anything in your bank account.', hidden=True)
         elif int(amount) <= 0: return await ctx.reply('The amount to deposit must be more than `0` coins!', hidden=True)
@@ -289,7 +289,7 @@ async def deposit(ctx:SlashContext, amount):
 async def withdraw(ctx:SlashContext, amount):
     if plugins.economy:
         if not amount.isdigit():
-            if amount == "max": amount = currency["wallet"][str(ctx.author.id)]
+            if str(amount) == "max": amount = currency["wallet"][str(ctx.author.id)]
             else: return await ctx.reply("The amount must be a number, or `max`.", hidden=True)
         elif currency['bank'] == 0: return await ctx.reply('You don\'t have anything in your bank account.', hidden=True)
         elif int(amount) <= 0: return await ctx.reply('The amount to withdraw must be more than `0` coins!', hidden=True)


### PR DESCRIPTION
### "max" and "all" Keywords in Deposit and Withdraw Commands
This is done to make Dank Memer users more familiar with the deposit and withdraw syntax as they start using isobot. However, if an invalid keyword (any value that isn't a number and isn't "max" or "all") is used as amount, it might break the bot. I will release a fix for this or I will fix it in the same issue.