### PR TITLE
Remove redundant parentheses from classes in framework

### DIFF
--- a/framework/isobot/colors.py
+++ b/framework/isobot/colors.py
@@ -1,5 +1,5 @@
 """Library used for stdout colors."""
-class Colors():
+class Colors:
     """Contains general stdout colors."""
     cyan = '\033[96m'
     red = '\033[91m'

--- a/framework/isobot/currency.py
+++ b/framework/isobot/currency.py
@@ -1,7 +1,7 @@
 import json
 import discord
 
-class Colors():
+class Colors:
     """Contains general stdout colors."""
     cyan = '\033[96m'
     red = '\033[91m'


### PR DESCRIPTION
I forgot that these are called classes, not functions