### PR TITLE
Add `/profile` command to let users view isobot profile stats

### DIFF
--- a/config/commands.json
+++ b/config/commands.json
@@ -9,7 +9,6 @@
     "disabled": false,
     "bugged": false
   },
-
   "hunt": {
       "name": "Hunt",
       "description": "Take out your hunting rifle and hunt down insects or animals to sell.",
@@ -40,7 +39,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "daily": {
       "name": "Daily",
       "description": "Claim your daily reward! (Once every day)",
@@ -71,7 +69,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "load": {
       "name": "Load Module",
       "description": "Load an individual module to the bots runtime instance.",
@@ -112,7 +109,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "balance": {
       "name": "Show Balance",
       "description": "See your own balance, or someone else's balance.",
@@ -123,7 +119,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "kick": {
       "name": "Kick Member",
       "description": "Kick a member from your guild.",
@@ -144,7 +139,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "warn": {
       "name": "Warn Member",
       "description": "Warn a member in your guild for a specific reason.",
@@ -165,7 +159,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "deposit": {
       "name": "Deposit Coins",
       "description": "Deposit some or all of your coins into your bank account.",
@@ -186,7 +179,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "beg": {
       "name": "Beg",
       "description": "Beg other people for quick money.",
@@ -207,7 +199,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "give": {
       "name": "Give Coins",
       "description": "Give coins to whoever you want.",
@@ -218,7 +209,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "rob": {
       "name": "Rob Member",
       "description": "Rob a user and loot them of their coins!",
@@ -239,7 +229,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "inventory": {
       "name": "Show Inventory",
       "description": "Shows the items you own, or the items someone else owns.",
@@ -250,7 +239,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "shop": {
       "name": "Display Shop Items",
       "description": "Shop for an individual item in the shop, and display its information.",
@@ -261,7 +249,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "buy": {
       "name": "Buy Shop Item",
       "description": "Buy an item from the shop with your coins.",
@@ -292,7 +279,6 @@
       "disabled": true,
       "bugged": false
   },
-
   "echo": {
       "name": "Echo",
       "description": "Sends a message in the respective channel.",
@@ -303,7 +289,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "whoami": {
       "name": "User Info",
       "description": "Show basic (and some detailed information) on you, or a specific user.",
@@ -314,7 +299,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "stroketranslate": {
       "name": "Stroke Translate",
       "description": "Generate random strokes from random text!",
@@ -335,7 +319,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "memes": {
       "name": "Memes",
       "description": "Get some high-quality memes from reddit. (Powered by PRAW, fetched from the /memes subreddit)",
@@ -386,7 +369,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "donate": {
       "name": "Donate",
       "description": "Donate any amount of coins to another user (with a donation ID).",
@@ -407,7 +389,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "status": {
       "name": "Bot Status",
       "description": "Returns general statistics on the current bot instance.",
@@ -418,7 +399,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "afk_set": {
       "name": "Set AFK Status",
       "description": "Going to be AFK? Use this command to set a AFK status so that people know when and why you are AFK.",
@@ -449,7 +429,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "autogrind": {
       "name": "Autogrind",
       "description": "Use this command to automatically let the bot grind coins and items for you, while you're AFK or doing other things.",
@@ -460,7 +439,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "rank": {
       "name": "Rank",
       "description": "Show your bot level/rank, or someone else's level/rank.",
@@ -491,7 +469,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "repo": {
       "name": "GitHub Repo",
       "description": "Shows the GitHub repository link of the bot. *Yes! Isobot is open-source.*",
@@ -502,7 +479,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "embedbuilder": {
       "name": "EmbedBuilder",
       "description": "Build an embed using a simple command and EmbedBuilder.",
@@ -513,7 +489,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "isobank_register": {
       "name": "IsoBank Register",
       "description": "Registers a new IsoBank account under your Discord account ID and your custom-set PIN.",
@@ -524,7 +499,6 @@
       "disabled": false,
       "bugged": false
   },
-
   "guessthenumber": {
       "name": "Guess-the-number",
       "description": "Play a simple minigame to guess the number that the bot is thinking of, from 1 to 10.",

--- a/config/commands.json
+++ b/config/commands.json
@@ -544,5 +544,15 @@
       "usable_by": "everyone",
       "disabled": false,
       "bugged": false
+  },
+  "profile": {
+    "name": "Show Isobot Profile Stats",
+    "description": "Shows basic stats about your isobot profile, or someone else's profile stats.",
+    "type": "general utilities",
+    "cooldown": null,
+    "args": ["user (optional)"],
+    "usable_by": "everyone",
+    "disabled": false,
+    "bugged": false
   }
 }

--- a/main.py
+++ b/main.py
@@ -1176,7 +1176,7 @@ async def highlow(ctx:SlashContext):
 
 @slash.slash(
     name="profile",
-    description="Shows basic stats about your isobot profile, or someone else's stats",
+    description="Shows basic stats about your isobot profile, or someone else's profile stats",
     options=[
         create_option(name="user", description="Whose isobot profile do you want to view?", option_type=6, required=False)
     ]

--- a/main.py
+++ b/main.py
@@ -1193,7 +1193,6 @@ async def profile(ctx: SlashContext, user: discord.User = None):
     # Maybe I should make a userdat system for collecting statistical data to process and display here, coming in a future update.
     await ctx.send(embed=localembed)
 
-
 # Initialization
 utils.ping.host()
 client.run(api.auth.get_token())

--- a/main.py
+++ b/main.py
@@ -1174,6 +1174,26 @@ async def highlow(ctx:SlashContext):
         else: return await ctx.send(f'Wrong! The number was {numb2}.')
     else: await ctx.send(f'wtf is {msg.content}?')
 
+@slash.slash(
+    name="profile",
+    description="Shows basic stats about your isobot profile, or someone else's stats",
+    options=[
+        create_option(name="user", description="Whose isobot profile do you want to view?", option_type=6, required=False)
+    ]
+)
+async def profile(ctx: SlashContext, user: discord.User = None):
+    if user == None: user = ctx.author
+    localembed = discord.Embed(title=f"{user.display_name}'s isobot stats", color=discord.Color.random())
+    localembed.set_thumbnail(url=user.avatar_url)
+    localembed.add_field(name="Level", value=f"Level {levels[str(user.id)]['level']} ({levels[str(user.id)]['xp']} XP)", inline=False)
+    localembed.add_field(name="Balance in Wallet", value=f"{currency['wallet'][str(user.id)]} coins", inline=True)
+    localembed.add_field(name="Balance in Bank Account", value=f"{currency['bank'][str(user.id)]} coins", inline=True)
+    localembed.add_field(name="Net-Worth", value=f"{currency['wallet'][str(user.id)] + currency['bank'][str(user.id)]} coins", inline=True)
+    # More stats will be added later
+    # Maybe I should make a userdat system for collecting statistical data to process and display here, coming in a future update.
+    await ctx.send(embed=localembed)
+
+
 # Initialization
 utils.ping.host()
 client.run(api.auth.get_token())


### PR DESCRIPTION
### `/profile` command
This command will let any user view basic isobot profile stats about themselves, or any other specified user. 

As of now, there isn't a proper userdat system or data after-processing, which means that the command cannot show more detailed info (eg: level progress, work history, rob history, gain/loss graphs etc.).
But the command **can** show all of these stats as of now:
* user level
* user xp
* wallet balance
* bank balance
* networth

*Remember, more changes will be added to this command soon.*