### PR TITLE
Fix duplicate naming error causing save fails when `save()` is called

### DIFF
--- a/config/commands.json
+++ b/config/commands.json
@@ -269,7 +269,7 @@
       "disabled": false,
       "bugged": false
   },
-  "open": {
+  "openlootbox": {
       "name": "Open Lootbox",
       "description": "Open a lootbox and get awesome coin and item rewards!",
       "type": "economy system",

--- a/main.py
+++ b/main.py
@@ -665,14 +665,14 @@ async def dig(ctx:SlashContext):
 
 #need help cuz i only got the idea (aka the logic) and not the code detail and stuff
 @slash.slash(
-    name='open',
+    name='openlootbox',
     description='Opens lootbox(es) in your inventory',
     options=[
         create_option(name='lootbox', description='What lootbox do you want to open?', option_type=3, required=True),
         create_option(name='amount', description='How many do you want to open?', option_type=4, required=True)
     ]
 )
-async def open(ctx:SlashContext, lootbox:str, amount:int):
+async def openlootbox(ctx:SlashContext, lootbox:str, amount:int):
     types = ["normal", "large", "special"]
     if amount <= 0: return await ctx.reply("You can't open 0 or below lootboxes! Don't be stupid.", hidden=True)
     if lootbox not in types: return await ctx.reply(f"wtf is {lootbox}?", hidden=True)


### PR DESCRIPTION
### Database `save()` Command Patch
This conflict was caused due to the `/open` command, which is also used as another command in the `save()` command. Due to this bug, whenever the database was supposed to save cached data, it would fail and return `BaseCommandObject` exception instead.
This caused many problems, including rendering the entire earning and spending logic in the economy system, useless.

This patch should fix it, and allow the database to save data correctly.