### PR TITLE
Make user networth display on `/balance` and `/networth` commands

### DIFF
--- a/config/commands.json
+++ b/config/commands.json
@@ -519,6 +519,16 @@
       "disabled": false,
       "bugged": false
   },
+  "networth": {
+    "name": "Show Networth",
+    "description": "Shows your networth, or someone else's networth.",
+    "type": "economy system",
+    "cooldown": 0,
+    "args": ["user (optional)"],
+    "usable_by": "everyone",
+    "disabled": false,
+    "bugged": false
+  },
   "profile": {
     "name": "Show Isobot Profile Stats",
     "description": "Shows basic stats about your isobot profile, or someone else's profile stats.",

--- a/main.py
+++ b/main.py
@@ -189,6 +189,7 @@ async def balance(ctx:SlashContext, user=None):
             e = discord.Embed(title=f'{user.display_name}\'s balance', color=color)
             e.add_field(name='Cash in wallet', value=f'{currency["wallet"][str(user.id)]} coin(s)', inline=True)
             e.add_field(name='Cash in bank account', value=f'{currency["bank"][str(user.id)]} coin(s)', inline=True)
+            e.add_field(name="Networth", value=f"{get_user_networth(user.id)} coin(s)", inline=True)
             await ctx.send(embed=e)
         except: await ctx.reply('Looks like that user is not indexed in our server. Try again later.')
     except Exception as e: await ctx.send(f'An error occured: `{e}`. This has automatically been reported to the devs.')

--- a/main.py
+++ b/main.py
@@ -45,6 +45,12 @@ def save():
     with open('database/presence.json', 'w+') as f: json.dump(user_presence, f, indent=4)
     with open('database/levels.json', 'w+') as f: json.dump(levels, f, indent=4)
 
+def get_user_networth(user_id:int):
+    nw = currency["wallet"][str(user_id)] + currency["bank"][str(user_id)]
+    for e in items[str(user_id)]:
+        if e != 0: nw += shopitem[e]["sell price"]
+    return nw
+
 if not os.path.isdir("logs"):
   os.mkdir('logs')
   try:

--- a/main.py
+++ b/main.py
@@ -667,14 +667,15 @@ async def whoami(ctx:SlashContext, user:discord.User=None):
         description=localembed_desc
     )
     localembed.set_thumbnail(url=pfp)
-    localembed.add_field(name='Username', value=username, inline=False)
-    localembed.add_field(name='Display Name', value=displayname, inline=False)
+    localembed.add_field(name='Username', value=username, inline=True)
+    localembed.add_field(name='Display Name', value=displayname, inline=True)
     localembed.add_field(name='Joined Discord on', value=registered, inline=False)
-    localembed.add_field(name='Avatar URL', value=f"[here!]({pfp})", inline=False)
+    localembed.add_field(name='Avatar URL', value=f"[here!]({pfp})", inline=True)
     role_render = ""
     for p in user.roles:
         if p != "everyone": role_render += f"<@&{p.id}> "
     localembed.add_field(name='Roles', value=role_render, inline=False)
+    localembed.add_field(name="Net worth", value=f"{get_user_networth(user.id)} coins", inline=False)
     await ctx.send(embed=localembed)
 
 # DevTools commands

--- a/main.py
+++ b/main.py
@@ -47,8 +47,8 @@ def save():
 
 def get_user_networth(user_id:int):
     nw = currency["wallet"][str(user_id)] + currency["bank"][str(user_id)]
-    for e in items[str(user_id)]:
-        if e != 0: nw += shopitem[e]["sell price"]
+    #for e in items[str(user_id)]:
+    #    if e != 0: nw += shopitem[e]["sell price"]
     return nw
 
 if not os.path.isdir("logs"):

--- a/main.py
+++ b/main.py
@@ -1087,6 +1087,22 @@ async def highlow(ctx:SlashContext):
         else: return await ctx.send(f'Wrong! The number was {numb2}.')
     else: await ctx.send(f'wtf is {msg.content}?')
 
+@slash.slash(
+    name="networth",
+    description="Get your networth, or another user's networth",
+    options=[
+        create_option(name="user", description="Whose networth do you want to find?", option_type=6, required=False)
+    ]
+)
+async def networth(ctx:SlashContext, user:discord.User=None):
+    if user == None: user = ctx.author
+    try:
+        ntw = get_user_networth(user.id)
+        localembed = discord.Embed(name=f"{user.display_name}'s networth", description=f"{ntw} coins", color=discord.Color.random())
+        await ctx.send(embed=localembed)
+    except KeyError: return await ctx.reply("Looks like that user isn't cached yet. Please try again later.", hidden=True)
+
+
 # Initialization
 utils.ping.host()
 client.run(api.auth.get_token())

--- a/main.py
+++ b/main.py
@@ -1211,7 +1211,7 @@ async def profile(ctx: SlashContext, user: discord.User = None):
     localembed.add_field(name="Level", value=f"Level {levels[str(user.id)]['level']} ({levels[str(user.id)]['xp']} XP)", inline=False)
     localembed.add_field(name="Balance in Wallet", value=f"{currency['wallet'][str(user.id)]} coins", inline=True)
     localembed.add_field(name="Balance in Bank Account", value=f"{currency['bank'][str(user.id)]} coins", inline=True)
-    localembed.add_field(name="Net-Worth", value=f"{currency['wallet'][str(user.id)] + currency['bank'][str(user.id)]} coins", inline=True)
+    localembed.add_field(name="Net-Worth", value=f"{get_user_networth(user.id)} coins", inline=True)
     # More stats will be added later
     # Maybe I should make a userdat system for collecting statistical data to process and display here, coming in a future update.
     await ctx.send(embed=localembed)


### PR DESCRIPTION
### Networth Display

*Suggested by GlitchedAI_3248 on Discord*

This system lets users view total computed net-worth of themselves, or any other user on the `/balance` command, `/networth` command, `/whoami` command, and more.
This was originally supposed to sum up the user's balance in their wallet and bank accounts, as well as parse every item's sell price in the user's inventory and return the value. However, I ran into some issues while making that work, so that is temporarily (or even permanently) disabled. I will add it back if i can fix the system.